### PR TITLE
Create tsmuxbusctl tool

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT(ts4100-utils, 1.0, mark@embeddedarm.com)
+AC_INIT(ts4100-utils, 1.0, support@embeddedarm.com)
 AC_CONFIG_SRCDIR([src/tshwctl.c])
 #AC_CONFIG_HEADERS([config.h])
 
@@ -12,7 +12,6 @@ AM_INIT_AUTOMAKE([1.00 foreign no-define])
 AC_PROG_CC
 
 # Checks for libraries.
-# FIXME: Replace `main' with a function in `-lm':
 AC_CHECK_LIB([gpiod], [gpiod_line_request_input], [], [AC_MSG_ERROR([libgpiod not found])])
 
 # Checks for header files.

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -3,3 +3,4 @@ ts8820ctl
 tshwctl
 tsmicroctl
 tszpuctl
+tsmuxbusctl

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,5 +18,9 @@ ts8820ctl_SOURCES = tszpufifo.c gpiolib.c fpga.c ts8820ctl.c ts8820.c
 ts8820ctl_LDFLAGS = -mcpu=cortex-a9
 ts8820ctl_CPPFLAGS = -Wall -DGITCOMMIT="\"${GITCOMMIT}\""
 
-bin_PROGRAMS = tshwctl tsmicroctl tszpuctl ts8820ctl
+tsmuxbusctl_SOURCES = tszpufifo.c gpiolib.c  fpga.c tsmuxbusctl.c
+tsmuxbusctl_LDFLAGS = -mcpu=cortex-a9
+tsmuxbusctl_CPPFLAGS = -Wall -DGITCOMMIT="\"${GITCOMMIT}\""
+
+bin_PROGRAMS = tshwctl tsmicroctl tszpuctl ts8820ctl tsmuxbusctl
 noinst_PROGRAMS = load_fpga

--- a/src/fpga.c
+++ b/src/fpga.c
@@ -12,7 +12,6 @@
 #include <assert.h>
 
 #include "i2c-dev.h"
-#include "fpga.h"
 
 static uint8_t i2c_addr;
 
@@ -36,26 +35,9 @@ int fpga_init(const char *i2c_bus, uint8_t addr)
 	return fd;
 }
 
-void fpoke8(int twifd, uint16_t addr, uint8_t data)
+int fpga_deinit(int twifd)
 {
-	int ret;
-
-	ret = fpokestream8(twifd, &data, addr, 1);
-	if (ret) {
-		perror("Failed to write to FPGA");
-	}
-}
-
-uint8_t fpeek8(int twifd, uint16_t addr)
-{
-	uint8_t data = 0;
-	int ret;
-	ret = fpeekstream8(twifd, &data, addr, 1);
-
-	if (ret) {
-		perror("Failed to read from FPGA");
-	}
-	return data;
+	return close(twifd);
 }
 
 int fpeekstream8(int twifd, uint8_t *data, uint16_t addr, int size)
@@ -118,4 +100,26 @@ int fpokestream8(int twifd, uint8_t *data, uint16_t addr, int size)
 		return 1;
 	}
 	return 0;
+}
+
+void fpoke8(int twifd, uint16_t addr, uint8_t data)
+{
+	int ret;
+
+	ret = fpokestream8(twifd, &data, addr, 1);
+	if (ret) {
+		perror("Failed to write to FPGA");
+	}
+}
+
+uint8_t fpeek8(int twifd, uint16_t addr)
+{
+	uint8_t data = 0;
+	int ret;
+	ret = fpeekstream8(twifd, &data, addr, 1);
+
+	if (ret) {
+		perror("Failed to read from FPGA");
+	}
+	return data;
 }

--- a/src/fpga.h
+++ b/src/fpga.h
@@ -2,6 +2,7 @@
 #define __FPGA_H_
 
 int fpga_init(const char *i2c_bus, uint8_t addr);
+int fpga_deinit(int twifd);
 int fpeekstream8(int twifd,  uint8_t *data, uint16_t addr, int size);
 int fpokestream8(int twifd, uint8_t *data, uint16_t addr, int size);
 uint8_t fpeek8(int twifd, uint16_t addr);

--- a/src/tsmuxbusctl.c
+++ b/src/tsmuxbusctl.c
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+
+/* Example application for communicating with MUXBUS based baseboards via
+ * TS-4100 ZPU MUXBUS FIFO implementation.
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "tszpufifo.h"
+#include "fpga.h"
+
+const char copyright[] = "Copyright (c) Technologic Systems - " __DATE__ " - "
+  GITCOMMIT;
+
+int get_model()
+{
+	FILE *proc;
+	char mdl[256];
+	char *ptr;
+
+	proc = fopen("/proc/device-tree/model", "r");
+	if (!proc) {
+		perror("model");
+		return 0;
+	}
+	fread(mdl, 256, 1, proc);
+	ptr = strstr(mdl, "TS-");
+	return strtoull(ptr+3, NULL, 16);
+}
+
+
+static void usage(char **argv) {
+	fprintf(stderr,
+	  "%s\n\n"
+	  "Usage: %s ADDRESS [VALUE]\n"
+	  "Technologic Systems ZPU MUXBUS demo tool\n\n"
+
+	  "  ADDRESS     The MUXBUS address to read/write 16-bit value\n"
+	  "  VALUE       Optional argument, write 16-bit VALUE to ADDRESS\n\n"
+
+	  "Print a 16-bit hex value to terminal indicating the value read from\n"
+	  "ADDRESS. On a write, VALUE is written to ADDRESS, and then read\n"
+	  "back. The resulting read is printed.\n\n"
+
+	  "Returns 0 on success, 1 on any error.\n\n",
+	  copyright, argv[0]
+	);
+}
+
+int main(int argc, char **argv) {
+	int twifd;
+	int model;
+	uint16_t addr, val;
+
+	if ((argc == 1) || (argc > 3) || !strncmp(argv[1], "-h", 2) ||
+	  !strncmp(argv[1], "--help", 6)) {
+		usage(argv);
+		return 1;
+	}
+
+	model = get_model();
+	if(model != 0x4100) {
+		fprintf(stderr, "Unsupported model 0x%X\n", model);
+		return 1;
+	}
+
+
+	twifd = fpga_init("/dev/i2c-2", 0x28);
+	if(twifd == -1) {
+		/* fpga_init() calls open() which fails with errno set */
+		perror("Can't open FPGA I2C bus");
+		return 1;
+	}
+
+	/* zpu_fifo_init() also returns irqfd, we don't need to worry about that
+	 * unless wanted. The irqfd is maintained by tszpufifo ctx */
+        if (zpu_fifo_init(twifd, FLOW_CTRL) == -1) return 1;
+
+	addr = (uint16_t)strtoul(argv[1], NULL, 0);
+
+	/* If VALUE was passed, write that first */
+	if (argc == 3) {
+		val = (uint16_t)strtoul(argv[2], NULL, 0);
+		zpu_muxbus_poke16(twifd, addr, val);
+	}
+
+	printf("0x%04X\n", zpu_muxbus_peek16(twifd, addr));
+
+	zpu_fifo_deinit(twifd);
+	fpga_deinit(twifd);
+
+	return 0;
+}

--- a/src/tszpufifo.c
+++ b/src/tszpufifo.c
@@ -168,6 +168,7 @@ void zpu_fifo_deinit(int twifd)
 {
 	fifo_flags |= (1<<25);
 	fpoke8(twifd, fifo_adr, fifo_flags >> 24);
+	close(irqfd);
 }
 
 /* The get and put functions are named from the CPU perspective, while variables

--- a/src/tszpufifo.h
+++ b/src/tszpufifo.h
@@ -1,6 +1,11 @@
 #ifndef __TSZPUFIFO_H__
 #define __TSZPUFIFO_H__
 
+enum flowcontrol {
+	NO_FLOW_CTRL = 0,
+	FLOW_CTRL = 1,
+};
+
 void zpu_fifo_deinit(int twifd);
 int32_t zpu_fifo_init(int twifd, int flow_control);
 size_t zpu_fifo_get(int twifd, uint8_t *buf, size_t size);


### PR DESCRIPTION
Initial creation of generic tool to communicate with the ZPU running the zpu_muxbus.bin application.
Based on routines originally created for the ts8820ctl application, this allows a more generic interface.